### PR TITLE
fix mutex_spop_counts_ mutext not init

### DIFF
--- a/include/nemo.h
+++ b/include/nemo.h
@@ -71,6 +71,7 @@ public:
 
         pthread_mutex_destroy(&(mutex_cursors_));
         pthread_mutex_destroy(&(mutex_dump_));
+        pthread_mutex_destroy(&(mutex_spop_counts_));
         //pthread_mutex_destroy(&(mutex_bgtask_));
     };
 

--- a/src/nemo.cc
+++ b/src/nemo.cc
@@ -25,7 +25,7 @@ Nemo::Nemo(const std::string &db_path, const Options &options)
 
    pthread_mutex_init(&(mutex_cursors_), NULL);
    pthread_mutex_init(&(mutex_dump_), NULL);
-
+   pthread_mutex_init(&(mutex_spop_counts_), NULL);
    if (db_path_[db_path_.length() - 1] != '/') {
      db_path_.append("/");
    }


### PR DESCRIPTION
fix mutex_spop_counts_ mutext not init, when run spop commend,the server will hang