### PR TITLE
use the correct variable size to limit the size of value in KV

### DIFF
--- a/src/nemo_kv.cc
+++ b/src/nemo_kv.cc
@@ -306,13 +306,14 @@ Status Nemo::Setrange(const std::string key, const int64_t offset, const std::st
     if (offset < 0) {
         return Status::Corruption("offset < 0");
     }
+
+    if (value.length() + offset > (1<<29)) {
+        return Status::Corruption("too big");
+    }
     //MutexLock l(&mutex_kv_);
     RecordLock l(&mutex_kv_record_, key);
     Status s = kv_db_->Get(rocksdb::ReadOptions(), key, &val);
     if (s.ok()) {
-        if (val.length() + offset > (1<<29)) {
-            return Status::Corruption("too big");
-        }
         if ((size_t)offset > val.length()) {
             val.resize(offset);
             new_val = val.append(value);


### PR DESCRIPTION
The maximum size of value in k-v is 1 << 29, which is 512M.
But we should use 'value.length() + offset > (1<<29)' instead of 'val.length() + offset > (1<<29)' to check the limit.