### PR TITLE
 fux bitset and bitget bug when the key is expire or deleted  … when the key is expire or deleted， the valure is not null string so when s.IsNotFound()， set the value to null string

### DIFF
--- a/src/nemo_bit.cc
+++ b/src/nemo_bit.cc
@@ -14,6 +14,9 @@ using namespace nemo;
 Status Nemo::BitSet(const std::string &key, const std::int64_t offset, const int64_t on, int64_t* res) {
     std::string value;
     Status s = kv_db_->Get(rocksdb::ReadOptions(), key, &value);
+    if (s.IsNotFound()) {
+        value = "";
+    }
     if (s.ok() || s.IsNotFound()) {
         size_t byte = offset >> 3;
         size_t bit = 7 - (offset & 0x7);
@@ -55,6 +58,9 @@ Status Nemo::BitSet(const std::string &key, const std::int64_t offset, const int
 Status Nemo::BitGet(const std::string &key, const std::int64_t offset, std::int64_t* res) {
     std::string value;
     Status s = kv_db_->Get(rocksdb::ReadOptions(), key, &value);
+    if (s.IsNotFound()) {
+        value = "";
+    }
     if (s.ok() || s.IsNotFound()) {
         size_t byte = offset >> 3;
         size_t bit = 7 - (offset & 0x7);

--- a/src/nemo_bit.cc
+++ b/src/nemo_bit.cc
@@ -37,7 +37,7 @@ Status Nemo::BitSet(const std::string &key, const std::int64_t offset, const int
         if (byte + 1 <= value_lenth) {
             value.replace(byte, 1, &byte_val, 1);
         } else {
-            value.append(byte - value_lenth -1, 0);
+            value.append(byte + 1 - value_lenth -1, 0);
             value.append(1, byte_val);
         }
         s = kv_db_->Put(rocksdb::WriteOptions(), key, value);

--- a/src/nemo_kv.cc
+++ b/src/nemo_kv.cc
@@ -426,8 +426,8 @@ bool Nemo::ScanKeysWithTTL(std::unique_ptr<rocksdb::DBNemo>& db, std::string& st
         key = it->key().ToString();
         if (stringmatchlen(pattern.data(), pattern.size(), key.data(), key.size(), 0) && key.substr(0, scan_keys_store_pre.size()) != scan_keys_store_pre) {
             keys.push_back(key);
-            (*count)--;
         }
+        (*count)--;
         it->Next();
     }
     if (it->Valid()) {//the scan is over in the kv_db_
@@ -461,8 +461,8 @@ bool Nemo::ScanKeys(std::unique_ptr<rocksdb::DBNemo>& db, const char kType, std:
         if (stringmatchlen(pattern.data(), pattern.size(), key.data() + 1, key.size() - 1, 0)) {
             key.erase(key.begin());//erase the first marked letter
             keys.push_back(key);
-            (*count)--;
         }
+        (*count)--;
         it->Next();
     }
     if (it->Valid() && it->key().ToString().at(0) == kType) {


### PR DESCRIPTION

when the key is expire or deleted， the valure is not null string
so when s.IsNotFound()， set the value to null string